### PR TITLE
Add multichannel device reconnection handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -622,16 +622,23 @@ class App {
 
         const found = devices.some(d => d.kind === 'audiooutput' && d.deviceId === prefs.outputDeviceId);
         const currentSink = this.audioManager.ioManager.audioElement?.sinkId;
+        const outputChannels = prefs.outputChannels || 2;
 
-        if (found) {
-            if (currentSink !== prefs.outputDeviceId) {
-                const success = await this.audioManager.ioManager.reapplyOutputDevice(prefs.outputDeviceId);
-                if (!success) {
-                    await this.audioManager.reset(prefs);
-                }
+        if (outputChannels > 2) {
+            if (found) {
+                await this.audioManager.reset(prefs);
             }
-        } else if (currentSink === prefs.outputDeviceId) {
-            await this.audioManager.reset(prefs);
+        } else {
+            if (found) {
+                if (currentSink !== prefs.outputDeviceId) {
+                    const success = await this.audioManager.ioManager.reapplyOutputDevice(prefs.outputDeviceId);
+                    if (!success) {
+                        await this.audioManager.reset(prefs);
+                    }
+                }
+            } else if (currentSink === prefs.outputDeviceId) {
+                await this.audioManager.reset(prefs);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- restart audio context when devicechange event fires for multichannel output

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c1e6228e4832aa19419e8c888ef61