### PR TITLE
Refactor device change handling

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -622,9 +622,8 @@ class App {
 
         const found = devices.some(d => d.kind === 'audiooutput' && d.deviceId === prefs.outputDeviceId);
         const currentSink = this.audioManager.ioManager.audioElement?.sinkId;
-        const outputChannels = prefs.outputChannels || 2;
 
-        if (outputChannels > 2) {
+        if (typeof currentSink === 'undefined') {
             if (found) {
                 await this.audioManager.reset(prefs);
             }


### PR DESCRIPTION
## Summary
- handle device changes based on currentSink instead of outputChannels

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_684c38bac334832aaf70939a27caeec5