### PR TITLE
Add low-latency stereo output option

### DIFF
--- a/js/electron/audioIntegration.js
+++ b/js/electron/audioIntegration.js
@@ -185,6 +185,10 @@ export async function showAudioConfigDialog(isElectron, audioPreferences, callba
             <option value="6" ${audioPreferences?.outputChannels === 6 ? 'selected' : ''}>6</option>
             <option value="8" ${audioPreferences?.outputChannels === 8 ? 'selected' : ''}>8</option>
           </select>
+          <div class="checkbox-container">
+            <input type="checkbox" id="low-latency-output" ${audioPreferences?.lowLatencyOutput ? 'checked' : ''}>
+            <label for="low-latency-output">${t('dialog.audioConfig.lowLatencyOutput')}</label>
+          </div>
         </div>
         <div class="device-section">
           <label for="sample-rate">${t('dialog.audioConfig.sampleRate')}</label>
@@ -316,6 +320,7 @@ export async function showAudioConfigDialog(isElectron, audioPreferences, callba
       const sampleRateSelect = document.getElementById('sample-rate');
       const useInputWithPlayerCheckbox = document.getElementById('use-input-with-player');
       const outputChannelsSelect = document.getElementById('output-channels');
+      const lowLatencyOutputCheckbox = document.getElementById('low-latency-output');
       const latencySelect = document.getElementById('latency');
       
       const inputDevice = inputDevices.find(d => d.deviceId === inputDeviceSelect.value);
@@ -323,6 +328,7 @@ export async function showAudioConfigDialog(isElectron, audioPreferences, callba
       const selectedSampleRate = parseInt(sampleRateSelect.value, 10);
       const useInputWithPlayer = useInputWithPlayerCheckbox.checked;
       const outputChannels = parseInt(outputChannelsSelect.value, 10);
+      const lowLatencyOutput = lowLatencyOutputCheckbox.checked;
       const selectedLatency = latencySelect.value;
       
       // Save preferences
@@ -333,6 +339,7 @@ export async function showAudioConfigDialog(isElectron, audioPreferences, callba
         outputDeviceLabel: outputDevice?.label || '',
         sampleRate: selectedSampleRate,
         useInputWithPlayer: useInputWithPlayer,
+        lowLatencyOutput: lowLatencyOutput,
         outputChannels: outputChannels,
         latencyHint: selectedLatency
       };

--- a/js/locales/ar.json5
+++ b/js/locales/ar.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "متوسط",
   "dialog.audioConfig.latency.high": "مرتفع (الأكثر استقرارًا)",
   "dialog.audioConfig.useInputWithPlayer": "استخدام إدخال الصوت حتى عند استخدام المشغل",
+  "dialog.audioConfig.lowLatencyOutput": "إخراج منخفض الكمون (مباشر)",
   "dialog.audioConfig.cancel": "إلغاء",
   "dialog.audioConfig.apply": "تطبيق",
   "dialog.audioConfig.updatedTitle": "تم تحديث إعدادات الصوت",

--- a/js/locales/en.json5
+++ b/js/locales/en.json5
@@ -146,6 +146,7 @@
   "dialog.audioConfig.latency.mid": "Mid",
   "dialog.audioConfig.latency.high": "High (Most stable)",
   "dialog.audioConfig.useInputWithPlayer": "Audio input even when using Player",
+  "dialog.audioConfig.lowLatencyOutput": "Low-latency output (direct)",
   "dialog.audioConfig.cancel": "Cancel",
   "dialog.audioConfig.apply": "Apply",
   "dialog.audioConfig.updatedTitle": "Audio Configuration Updated",

--- a/js/locales/es.json5
+++ b/js/locales/es.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "Media",
   "dialog.audioConfig.latency.high": "Alta (Más estable)",
   "dialog.audioConfig.useInputWithPlayer": "Entrada de audio incluso cuando se usa el reproductor",
+  "dialog.audioConfig.lowLatencyOutput": "Salida de baja latencia (directa)",
   "dialog.audioConfig.cancel": "Cancelar",
   "dialog.audioConfig.apply": "Aplicar",
   "dialog.audioConfig.updatedTitle": "Configuración de audio actualizada",

--- a/js/locales/fr.json5
+++ b/js/locales/fr.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "Moyenne",
   "dialog.audioConfig.latency.high": "Élevée (Plus stable)",
   "dialog.audioConfig.useInputWithPlayer": "Entrée audio même lors de l'utilisation du lecteur",
+  "dialog.audioConfig.lowLatencyOutput": "Sortie à faible latence (directe)",
   "dialog.audioConfig.cancel": "Annuler",
   "dialog.audioConfig.apply": "Appliquer",
   "dialog.audioConfig.updatedTitle": "Configuration audio mise à jour",

--- a/js/locales/hi.json5
+++ b/js/locales/hi.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "मध्यम",
   "dialog.audioConfig.latency.high": "उच्च (सबसे स्थिर)",
   "dialog.audioConfig.useInputWithPlayer": "प्लेयर का उपयोग करते समय भी ऑडियो इनपुट",
+  "dialog.audioConfig.lowLatencyOutput": "न्यून विलंबता आउटपुट (प्रत्यक्ष)",
   "dialog.audioConfig.cancel": "रद्द करें",
   "dialog.audioConfig.apply": "लागू करें",
   "dialog.audioConfig.updatedTitle": "ऑडियो विन्यास अपडेट हुआ",

--- a/js/locales/ja.json5
+++ b/js/locales/ja.json5
@@ -144,6 +144,7 @@
   "dialog.audioConfig.latency.mid": "中",
   "dialog.audioConfig.latency.high": "高 (最も安定)",
   "dialog.audioConfig.useInputWithPlayer": "プレーヤー使用時も音声入力を有効にする",
+  "dialog.audioConfig.lowLatencyOutput": "低レイテンシー出力(直接)",
   "dialog.audioConfig.cancel": "キャンセル",
   "dialog.audioConfig.apply": "適用",
   "dialog.audioConfig.updatedTitle": "オーディオ設定が更新されました",

--- a/js/locales/ko.json5
+++ b/js/locales/ko.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "중간",
   "dialog.audioConfig.latency.high": "높음 (가장 안정적)",
   "dialog.audioConfig.useInputWithPlayer": "플레이어 사용 시에도 오디오 입력 사용",
+  "dialog.audioConfig.lowLatencyOutput": "저지연 출력(직접)",
   "dialog.audioConfig.cancel": "취소",
   "dialog.audioConfig.apply": "적용",
   "dialog.audioConfig.updatedTitle": "오디오 설정 업데이트됨",

--- a/js/locales/pt.json5
+++ b/js/locales/pt.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "Média",
   "dialog.audioConfig.latency.high": "Alta (Mais estável)",
   "dialog.audioConfig.useInputWithPlayer": "Entrada de áudio mesmo ao usar o Player",
+  "dialog.audioConfig.lowLatencyOutput": "Saída de baixa latência (direta)",
   "dialog.audioConfig.cancel": "Cancelar",
   "dialog.audioConfig.apply": "Aplicar",
   "dialog.audioConfig.updatedTitle": "Configuração de Áudio Atualizada",

--- a/js/locales/ru.json5
+++ b/js/locales/ru.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "Средняя",
   "dialog.audioConfig.latency.high": "Высокая (Наиболее стабильная)",
   "dialog.audioConfig.useInputWithPlayer": "Использовать аудиовход даже при использовании проигрывателя",
+  "dialog.audioConfig.lowLatencyOutput": "Низкая задержка вывода (напрямую)",
   "dialog.audioConfig.cancel": "Отмена",
   "dialog.audioConfig.apply": "Применить",
   "dialog.audioConfig.updatedTitle": "Аудиоконфигурация обновлена",

--- a/js/locales/zh.json5
+++ b/js/locales/zh.json5
@@ -145,6 +145,7 @@
   "dialog.audioConfig.latency.mid": "中",
   "dialog.audioConfig.latency.high": "高（最稳定）",
   "dialog.audioConfig.useInputWithPlayer": "使用播放器时仍启用音频输入",
+  "dialog.audioConfig.lowLatencyOutput": "低延迟输出(直接)",
   "dialog.audioConfig.cancel": "取消",
   "dialog.audioConfig.apply": "应用",
   "dialog.audioConfig.updatedTitle": "音频设置已更新",


### PR DESCRIPTION
## Summary
- allow direct connection for 2‑channel output
- expose a **Low Latency Output** checkbox in the audio config dialog
- store new option in user preferences
- update translations

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint js/audio/audio-io-manager.js js/electron/audioIntegration.js` *(fails: couldn't find ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_684c72bbca00832a85eaa94e6f898d27