### PR TITLE
Fix plugin drag layout

### DIFF
--- a/effetune.css
+++ b/effetune.css
@@ -474,6 +474,7 @@ input[type="checkbox"] {
     border-radius: 4px;
     transition: background-color 0.2s;
     width: auto; /* Changed from fixed width to auto */
+    position: relative; /* Ensure child elements are positioned correctly */
 }
 
 /* Column control buttons */


### PR DESCRIPTION
## Summary
- add `position: relative` to pipeline items so drag handles don't pull extra plugins along

## Testing
- `npm install puppeteer` *(fails: host blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68545aa7a89c832a98b584ce6681d86b