### PR TITLE
Fix plugin drag artifact

### DIFF
--- a/effetune.css
+++ b/effetune.css
@@ -474,6 +474,7 @@ input[type="checkbox"] {
     border-radius: 4px;
     transition: background-color 0.2s;
     width: auto; /* Changed from fixed width to auto */
+    overflow: hidden; /* Prevent UI overflow from affecting drag image */
 }
 
 /* Column control buttons */


### PR DESCRIPTION
## Summary
- hide overflow on `.pipeline-item` so plugin UI doesn't affect the drag image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68545ee79614832ab7b2834db413ff1e