### PR TITLE
Fix plugin drag visuals by ensuring responsive canvas widths

### DIFF
--- a/plugins/analyzer/spectrogram.js
+++ b/plugins/analyzer/spectrogram.js
@@ -397,10 +397,13 @@ class SpectrogramPlugin extends PluginBase {
 
         const graphContainer = document.createElement('div');
         graphContainer.className = 'graph-container';
-        graphContainer.style.position = 'relative'; graphContainer.style.width = '1024px'; graphContainer.style.height = '480px';
+        graphContainer.style.position = 'relative';
+        graphContainer.style.width = '100%';
+        graphContainer.style.height = '480px';
         const canvas = document.createElement('canvas');
         canvas.width = 2048; canvas.height = 960; // Internal buffer size
-        canvas.style.width = '1024px'; canvas.style.height = '480px'; // CSS display size
+        canvas.style.width = '100%';
+        canvas.style.height = '480px'; // CSS display size
         graphContainer.appendChild(canvas);
         this.canvas = canvas;
         this.canvasCtx = this.canvas.getContext('2d', { alpha: false });

--- a/plugins/analyzer/spectrum_analyzer.js
+++ b/plugins/analyzer/spectrum_analyzer.js
@@ -314,11 +314,14 @@ class SpectrumAnalyzerPlugin extends PluginBase {
 
         const graphContainer = document.createElement('div');
         graphContainer.className = 'graph-container';
-        graphContainer.style.position = 'relative'; graphContainer.style.width = '1024px'; graphContainer.style.height = '480px';
+        graphContainer.style.position = 'relative';
+        graphContainer.style.width = '100%';
+        graphContainer.style.height = '480px';
         
         const canvas = document.createElement('canvas');
         canvas.width = 2048; canvas.height = 960;
-        canvas.style.width = '1024px'; canvas.style.height = '480px';
+        canvas.style.width = '100%';
+        canvas.style.height = '480px';
         graphContainer.appendChild(canvas);
         this.canvas = canvas;
 

--- a/plugins/dynamics/compressor.js
+++ b/plugins/dynamics/compressor.js
@@ -541,7 +541,7 @@ class CompressorPlugin extends PluginBase {
         // to ensure sharpness when scaled or on high-DPI screens.
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/dynamics/gate.js
+++ b/plugins/dynamics/gate.js
@@ -705,7 +705,7 @@ class GatePlugin extends PluginBase {
         // to ensure sharpness when scaled or on high-DPI screens.
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/dynamics/multiband_compressor.js
+++ b/plugins/dynamics/multiband_compressor.js
@@ -1068,7 +1068,7 @@ class MultibandCompressorPlugin extends PluginBase {
       // to ensure sharpness when scaled or on high-DPI screens.
       canvas.width = 320;
       canvas.height = 320;
-      canvas.style.width = '160px';
+      canvas.style.width = '100%';
       canvas.style.height = '160px';
       canvas.style.backgroundColor = '#222';
       const label = document.createElement('div');

--- a/plugins/dynamics/multiband_transient.js
+++ b/plugins/dynamics/multiband_transient.js
@@ -739,7 +739,7 @@ class MultibandTransientPlugin extends PluginBase {
             const canvas = document.createElement('canvas');
             canvas.width = 612;
             canvas.height = 300;
-            canvas.style.width = '308px';
+            canvas.style.width = '100%';
             canvas.style.height = '150px';
             canvas.style.backgroundColor = '#1a1a1a';
             const label = document.createElement('div');

--- a/plugins/eq/band_pass_filter.js
+++ b/plugins/eq/band_pass_filter.js
@@ -287,7 +287,7 @@ class BandPassFilterPlugin extends PluginBase {
     const canvas = document.createElement("canvas");
     canvas.width = 1200;
     canvas.height = 480;
-    canvas.style.width = "600px";
+    canvas.style.width = "100%";
     canvas.style.height = "240px";
     graphContainer.appendChild(canvas);
 

--- a/plugins/eq/fifteen_band_geq.js
+++ b/plugins/eq/fifteen_band_geq.js
@@ -301,7 +301,7 @@ return data; // Return the modified buffer
         // to ensure sharpness when scaled or on high-DPI screens.
         canvas.width = 1200;
         canvas.height = 480;
-        canvas.style.width = '600px';
+        canvas.style.width = '100%';
         canvas.style.height = '240px';
         
         graphContainer.appendChild(canvas);

--- a/plugins/eq/fifteen_band_peq.css
+++ b/plugins/eq/fifteen_band_peq.css
@@ -17,7 +17,7 @@
 
 .fifteen-band-peq-plugin-ui .fifteen-band-peq-graph {
     position: relative;
-    width: 1024px;
+    width: 100%;
     height: 480px;
     background-color: #1a1a1a;
 }

--- a/plugins/eq/five_band_peq.css
+++ b/plugins/eq/five_band_peq.css
@@ -17,7 +17,7 @@
 
 .five-band-peq-plugin-ui .five-band-peq-graph {
     position: relative;
-    width: 1024px;
+    width: 100%;
     height: 480px;
     background-color: #1a1a1a;
 }

--- a/plugins/eq/hi_pass_filter.js
+++ b/plugins/eq/hi_pass_filter.js
@@ -228,7 +228,7 @@ class HiPassFilterPlugin extends PluginBase {
     const canvas = document.createElement("canvas");
     canvas.width = 1200;
     canvas.height = 480;
-    canvas.style.width = "600px";
+    canvas.style.width = "100%";
     canvas.style.height = "240px";
     graphContainer.appendChild(canvas);
 

--- a/plugins/eq/lo_pass_filter.js
+++ b/plugins/eq/lo_pass_filter.js
@@ -233,7 +233,7 @@ class LoPassFilterPlugin extends PluginBase {
     const canvas = document.createElement("canvas");
     canvas.width = 1200;
     canvas.height = 480;
-    canvas.style.width = "600px";
+    canvas.style.width = "100%";
     canvas.style.height = "240px";
     graphContainer.appendChild(canvas);
 

--- a/plugins/eq/loudness_equalizer.js
+++ b/plugins/eq/loudness_equalizer.js
@@ -276,7 +276,7 @@ class LoudnessEqualizerPlugin extends PluginBase {
         const canvas = document.createElement('canvas');
         canvas.width = 1200;
         canvas.height = 480;
-        canvas.style.width = '600px';
+        canvas.style.width = '100%';
         canvas.style.height = '240px';
 
         // Helper function to create the onChange handler for controls

--- a/plugins/eq/narrow_range.js
+++ b/plugins/eq/narrow_range.js
@@ -486,7 +486,7 @@ class NarrowRangePlugin extends PluginBase {
     const canvas = document.createElement("canvas");
     canvas.width = 1200;
     canvas.height = 480;
-    canvas.style.width = "600px";
+    canvas.style.width = "100%";
     canvas.style.height = "240px";
     graphContainer.appendChild(canvas);
 

--- a/plugins/eq/tilt_eq.js
+++ b/plugins/eq/tilt_eq.js
@@ -325,7 +325,7 @@ return data; // Return the modified buffer
         // Configure canvas (created earlier)
         canvas.width = 1200;
         canvas.height = 480;
-        canvas.style.width = '600px';
+        canvas.style.width = '100%';
         canvas.style.height = '240px';
         graphContainer.appendChild(canvas);
 

--- a/plugins/eq/tone_control.js
+++ b/plugins/eq/tone_control.js
@@ -302,7 +302,7 @@ class ToneControlPlugin extends PluginBase {
         // Configure canvas (created earlier)
         canvas.width = 1200;
         canvas.height = 480;
-        canvas.style.width = '600px';
+        canvas.style.width = '100%';
         canvas.style.height = '240px';
         graphContainer.appendChild(canvas);
 

--- a/plugins/saturation/dynamic_saturation.js
+++ b/plugins/saturation/dynamic_saturation.js
@@ -258,7 +258,7 @@ class DynamicSaturationPlugin extends PluginBase {
         const canvas = document.createElement('canvas');
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/saturation/hard_clipping.js
+++ b/plugins/saturation/hard_clipping.js
@@ -341,7 +341,7 @@ class HardClippingPlugin extends PluginBase {
         const canvas = document.createElement('canvas');
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/saturation/harmonic_distortion.js
+++ b/plugins/saturation/harmonic_distortion.js
@@ -265,7 +265,7 @@ class HarmonicDistortionPlugin extends PluginBase {
         const canvas = document.createElement('canvas');
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/saturation/multiband_saturation.js
+++ b/plugins/saturation/multiband_saturation.js
@@ -705,7 +705,7 @@ class MultibandSaturationPlugin extends PluginBase {
             const canvas = document.createElement('canvas');
             canvas.width = 320;
             canvas.height = 320;
-            canvas.style.width = '160px';
+            canvas.style.width = '100%';
             canvas.style.height = '160px';
             canvas.style.backgroundColor = '#222';
             const label = document.createElement('div');

--- a/plugins/saturation/saturation.js
+++ b/plugins/saturation/saturation.js
@@ -170,7 +170,7 @@ class SaturationPlugin extends PluginBase {
         const canvas = document.createElement('canvas');
         canvas.width = 400;
         canvas.height = 400;
-        canvas.style.width = '200px';
+        canvas.style.width = '100%';
         canvas.style.height = '200px';
         canvas.style.backgroundColor = '#222';
         this.canvas = canvas;

--- a/plugins/saturation/sub_synth.js
+++ b/plugins/saturation/sub_synth.js
@@ -310,7 +310,7 @@ class SubSynthPlugin extends PluginBase {
     const canvas = document.createElement("canvas");
     canvas.width = 1200;
     canvas.height = 480;
-    canvas.style.width = "600px";
+    canvas.style.width = "100%";
     canvas.style.height = "240px";
     graphContainer.appendChild(canvas);
     this.canvas = canvas; // Store canvas reference on instance


### PR DESCRIPTION
## Summary
- keep canvas elements responsive by setting width to `100%` in various plugins
- update PEQ graph CSS to be responsive

## Testing
- `npm test` *(fails: Missing script)*
- `npx eslint .` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_b_68553bbff478832a981945314ce3686f