### PR TITLE
Add Mac build instructions for Horn Resonator Plus

### DIFF
--- a/docs/plugins/resonator.md
+++ b/docs/plugins/resonator.md
@@ -142,3 +142,24 @@ For each resonator:
    - Make small adjustments to frequencies and decay times.
    - Enable/disable individual resonators to find the perfect combination.
    - Remember that subtle changes can have a significant impact on the overall sound.
+
+## Building the Horn Resonator Plus WebAssembly Module
+
+The `Horn Resonator Plus` effect uses a WebAssembly module for optimal performance.
+If you modify `horn_resonator_plus.c`, rebuild the module as follows:
+
+1. Install the [WASI SDK](https://github.com/WebAssembly/wasi-sdk/) so that `wasm32-wasi-clang` is available.
+   On macOS you can use Homebrew:
+
+   ```bash
+   brew install wasi-sdk
+   ```
+
+2. Run the build script from the project root:
+
+   ```bash
+   cd plugins/resonator/wasm
+   ./build_wasm.sh
+   ```
+
+   The script automatically detects the `wasi-sdk` installation or falls back to the system `clang`.

--- a/plugins/resonator/wasm/build_wasm.sh
+++ b/plugins/resonator/wasm/build_wasm.sh
@@ -1,3 +1,20 @@
-#!/bin/bash
-set -e
-clang --target=wasm32 -O3 -nostdlib -Wl,--no-entry -Wl,--export-all -msimd128 -o horn_resonator_plus.wasm horn_resonator_plus.c
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the appropriate clang compiler for WebAssembly.
+if command -v wasm32-wasi-clang >/dev/null 2>&1; then
+    CC=wasm32-wasi-clang
+    SYSROOT=""
+elif [[ -n "${WASI_SDK_PATH:-}" ]] && [[ -x "${WASI_SDK_PATH}/bin/clang" ]]; then
+    CC="${WASI_SDK_PATH}/bin/clang"
+    SYSROOT="--sysroot=${WASI_SDK_PATH}/share/wasi-sysroot"
+else
+    CC=clang
+    SYSROOT=""
+    echo "Using system clang. Set WASI_SDK_PATH or install wasi-sdk for best results." >&2
+fi
+
+$CC --target=wasm32-wasi -O3 -nostdlib $SYSROOT \
+    -Wl,--no-entry -Wl,--export-all -msimd128 \
+    horn_resonator_plus.c -lc -lm \
+    -o horn_resonator_plus.wasm


### PR DESCRIPTION
## Summary
- enhance `build_wasm.sh` to use wasi-sdk if available
- document how to build the Horn Resonator Plus WASM module on macOS

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6855d3add2d4832aa8ef013afb68e660