### PR TITLE
Improve WASM loading error handling

### DIFF
--- a/js/audio-manager.js
+++ b/js/audio-manager.js
@@ -110,6 +110,17 @@ export class AudioManager {
                             isSleepMode: data.isSleepMode,
                             sampleRate: this.audioContext.sampleRate
                         });
+                    } else if (data.type === 'pluginError') {
+                        // Forward plugin error to UI and plugin instances
+                        this.dispatchEvent('pluginError', {
+                            pluginType: data.pluginType,
+                            message: data.message
+                        });
+                        for (const plugin of this.pipeline) {
+                            if (plugin.constructor.name === data.pluginType) {
+                                plugin._handleError('Worklet Error', data.message);
+                            }
+                        }
                     }
                 };
             }

--- a/js/audio/event-manager.js
+++ b/js/audio/event-manager.js
@@ -11,7 +11,8 @@ export class EventManager {
         
         // Event listeners for audio state changes
         this.eventListeners = {
-            sleepModeChanged: []
+            sleepModeChanged: [],
+            pluginError: []
         };
         
         // Setup user activity detection

--- a/plugins/audio-processor.js
+++ b/plugins/audio-processor.js
@@ -111,10 +111,23 @@ class PluginProcessor extends AudioWorkletProcessor {
         if (wasmPath) {
             try {
                 const resp = await fetch(wasmPath);
+                if (!resp.ok) {
+                    this.port.postMessage({
+                        type: 'pluginError',
+                        pluginType,
+                        message: `Failed to load wasm (HTTP ${resp.status})`
+                    });
+                    throw new Error(`HTTP ${resp.status}`);
+                }
                 const bytes = await resp.arrayBuffer();
                 const mod = await WebAssembly.instantiate(bytes, {});
                 wasmInstance = mod.instance;
             } catch (e) {
+                this.port.postMessage({
+                    type: 'pluginError',
+                    pluginType,
+                    message: `Failed to load wasm: ${e.message}`
+                });
                 console.error(`Failed to load wasm for ${pluginType}:`, e);
             }
         }


### PR DESCRIPTION
## Summary
- report plugin WASM load failures from the audio worklet
- forward the error to the UI and plugin instances

## Testing
- `node -e "console.log('Node version', process.version)"`


------
https://chatgpt.com/codex/tasks/task_b_6855dad77f90832a90e7a3a49b97563e