### PR TITLE
Fix Horn Resonator Plus wasm access

### DIFF
--- a/plugins/resonator/horn_resonator_plus.js
+++ b/plugins/resonator/horn_resonator_plus.js
@@ -1089,7 +1089,7 @@ class HornResonatorPlusPlugin extends PluginBase {
                 context.sr = sr; context.chs = chs; context.bs = bs;
                 ['ln','th','mo','cv','dp','tr','co','wg'].forEach(k => { context[k] = parameters[k]; });
                 context.bufPtr = wasm.exports.hrp_get_buffer();
-                context.buffer = new Float32Array(wasm.memory.buffer, context.bufPtr, chs * bs);
+                context.buffer = new Float32Array(wasm.exports.memory.buffer, context.bufPtr, chs * bs);
                 context.initialized = true;
             }
 


### PR DESCRIPTION
## Summary
- reference exported WebAssembly memory when initializing Horn Resonator Plus

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6855e2f31164832a9f1b5ed784e2588d