### PR TITLE
Optimize resonator filter state storage

### DIFF
--- a/plugins/resonator/horn_resonator.js
+++ b/plugins/resonator/horn_resonator.js
@@ -162,19 +162,22 @@ class HornResonatorPlugin extends PluginBase {
                 const a2_c = (omega2 - k + 1.0) * invDen;
                 context.lrCoeffs = { b0_lp, b1_lp, b2_lp, b0_hp, b1_hp, b2_hp, a1_c, a2_c };
 
-                // Initialize crossover filter states
-                const createCrossoverStage = () => Array.from({length: chs}, () => ({x1: DC_OFFSET, x2: -DC_OFFSET, y1: DC_OFFSET, y2: -DC_OFFSET}));
-                if (!context.lrStates || !context.lrStates.low || context.lrStates.low[0].length !== chs) {
+                // Initialize crossover filter states as flat arrays
+                // [x1_1, x2_1, y1_1, y2_1, x1_2, x2_2, y1_2, y2_2]
+                const initStage = () => new Float32Array([
+                    DC_OFFSET, -DC_OFFSET, DC_OFFSET, -DC_OFFSET,
+                    DC_OFFSET, -DC_OFFSET, DC_OFFSET, -DC_OFFSET
+                ]);
+                const createCrossoverArray = () => Array.from({length: chs}, () => initStage());
+                if (!context.lrStates || !context.lrStates.low || context.lrStates.low.length !== chs) {
                     context.lrStates = {
-                        low: [ createCrossoverStage(), createCrossoverStage() ], // 2 stages LP
-                        high: [ createCrossoverStage(), createCrossoverStage() ] // 2 stages HP
+                        low: createCrossoverArray(),
+                        high: createCrossoverArray()
                     };
                 } else {
-                    for (let stage = 0; stage < 2; ++stage) { // Reset states
-                        for (let ch = 0; ch < chs; ++ch) {
-                            context.lrStates.low[stage][ch] = {x1: DC_OFFSET, x2: -DC_OFFSET, y1: DC_OFFSET, y2: -DC_OFFSET};
-                            context.lrStates.high[stage][ch] = {x1: DC_OFFSET, x2: -DC_OFFSET, y1: DC_OFFSET, y2: -DC_OFFSET};
-                        }
+                    for (let ch = 0; ch < chs; ++ch) {
+                        context.lrStates.low[ch] = initStage();
+                        context.lrStates.high[ch] = initStage();
                     }
                 }
 
@@ -212,8 +215,8 @@ class HornResonatorPlugin extends PluginBase {
 
             // Crossover filter coefficients and states
             const { b0_lp, b1_lp, b2_lp, b0_hp, b1_hp, b2_hp, a1_c, a2_c } = context.lrCoeffs;
-            const lpStages = context.lrStates.low;  // [2][chs] Low-pass states
-            const hpStages = context.lrStates.high; // [2][chs] High-pass states
+            const lpStates = context.lrStates.low;  // [chs][8] Low-pass states
+            const hpStates = context.lrStates.high; // [chs][8] High-pass states
 
             // Low-band delay buffer and index array
             const lowDelay = context.lowDelay;       // [chs][N] Delay buffer
@@ -232,10 +235,8 @@ class HornResonatorPlugin extends PluginBase {
                 let rm_x1 = rm_x1_states[ch]; // Mouth reflection filter states
                 let rm_y1 = rm_y1_states[ch];
 
-                const lpState1 = lpStages[0][ch]; // Crossover filter states
-                const lpState2 = lpStages[1][ch];
-                const hpState1 = hpStages[0][ch];
-                const hpState2 = hpStages[1][ch];
+                const lpState = lpStates[ch];
+                const hpState = hpStates[ch];
 
                 let currentLowDelayWriteIdx = lowDelayIdx[ch]; // Low-band delay state
                 const currentLowDelayLine = lowDelay[ch];
@@ -249,18 +250,18 @@ class HornResonatorPlugin extends PluginBase {
                     let outputLow, outputHigh;
 
                     // Low-pass path - Stage 1 (DF-II Transposed)
-                    y1_lp = b0_lp * inputSample + b1_lp * lpState1.x1 + b2_lp * lpState1.x2 - a1_c * lpState1.y1 - a2_c * lpState1.y2;
-                    lpState1.x2 = lpState1.x1; lpState1.x1 = inputSample; lpState1.y2 = lpState1.y1; lpState1.y1 = y1_lp;
+                    y1_lp = b0_lp * inputSample + b1_lp * lpState[0] + b2_lp * lpState[1] - a1_c * lpState[2] - a2_c * lpState[3];
+                    lpState[1] = lpState[0]; lpState[0] = inputSample; lpState[3] = lpState[2]; lpState[2] = y1_lp;
                     // Low-pass path - Stage 2
-                    outputLow = b0_lp * y1_lp + b1_lp * lpState2.x1 + b2_lp * lpState2.x2 - a1_c * lpState2.y1 - a2_c * lpState2.y2;
-                    lpState2.x2 = lpState2.x1; lpState2.x1 = y1_lp; lpState2.y2 = lpState2.y1; lpState2.y1 = outputLow;
+                    outputLow = b0_lp * y1_lp + b1_lp * lpState[4] + b2_lp * lpState[5] - a1_c * lpState[6] - a2_c * lpState[7];
+                    lpState[5] = lpState[4]; lpState[4] = y1_lp; lpState[7] = lpState[6]; lpState[6] = outputLow;
 
                     // High-pass path - Stage 1
-                    y1_hp = b0_hp * inputSample + b1_hp * hpState1.x1 + b2_hp * hpState1.x2 - a1_c * hpState1.y1 - a2_c * hpState1.y2;
-                    hpState1.x2 = hpState1.x1; hpState1.x1 = inputSample; hpState1.y2 = hpState1.y1; hpState1.y1 = y1_hp;
+                    y1_hp = b0_hp * inputSample + b1_hp * hpState[0] + b2_hp * hpState[1] - a1_c * hpState[2] - a2_c * hpState[3];
+                    hpState[1] = hpState[0]; hpState[0] = inputSample; hpState[3] = hpState[2]; hpState[2] = y1_hp;
                     // High-pass path - Stage 2
-                    outputHigh = b0_hp * y1_hp + b1_hp * hpState2.x1 + b2_hp * hpState2.x2 - a1_c * hpState2.y1 - a2_c * hpState2.y2;
-                    hpState2.x2 = hpState2.x1; hpState2.x1 = y1_hp; hpState2.y2 = hpState2.y1; hpState2.y1 = outputHigh;
+                    outputHigh = b0_hp * y1_hp + b1_hp * hpState[4] + b2_hp * hpState[5] - a1_c * hpState[6] - a2_c * hpState[7];
+                    hpState[5] = hpState[4]; hpState[4] = y1_hp; hpState[7] = hpState[6]; hpState[6] = outputHigh;
 
                     // --- Propagate waves along the horn segments ---
                     // Calculate scattering at junctions j=0 to N-1 and apply damping (g).


### PR DESCRIPTION
## Summary
- reduce property overhead in horn resonator filters
- use flat `Float32Array` structures for filter states

## Testing
- `npm test` *(fails: Missing script)*
- `node --check plugins/resonator/horn_resonator.js && node --check plugins/resonator/horn_resonator_plus.js`

------
https://chatgpt.com/codex/tasks/task_b_6856673717c8832aa5314baf4967a60f