### PR TITLE
Add processing time logging for HornResonatorPlus

### DIFF
--- a/plugins/audio-processor.js
+++ b/plugins/audio-processor.js
@@ -540,12 +540,36 @@ class PluginProcessor extends AudioWorkletProcessor {
             // --- 9d. Execute Plugin Processor Function ---
             let result; // Can be the modified processingBuffer or a new buffer returned by processor
             try {
-                 result = processor.call(context, context, processingBuffer, processingParams, time);
-                 // Update context state potentially modified by the processor
-                 pluginContexts.set(plugin.id, context);
+                // Measure processing time for HornResonatorPlusPlugin only
+                let startTime;
+                if (plugin.type === 'HornResonatorPlusPlugin') {
+                    if (!context._timing) {
+                        context._timing = { sum: 0, count: 0, lastLogTime: time };
+                    }
+                    startTime = performance.now();
+                }
+
+                result = processor.call(context, context, processingBuffer, processingParams, time);
+
+                if (plugin.type === 'HornResonatorPlusPlugin' && startTime !== undefined) {
+                    const elapsed = performance.now() - startTime;
+                    const t = context._timing;
+                    t.sum += elapsed;
+                    t.count += 1;
+                    if (time - t.lastLogTime >= 10) {
+                        const avg = t.sum / t.count;
+                        console.log(`HornResonatorPlus average processing time: ${avg.toFixed(4)} ms`);
+                        t.sum = 0;
+                        t.count = 0;
+                        t.lastLogTime = time;
+                    }
+                }
+
+                // Update context state potentially modified by the processor
+                pluginContexts.set(plugin.id, context);
             } catch(e) {
-                 console.error(`Error executing plugin ${plugin.id} (${plugin.type}):`, e);
-                 result = processingBuffer; // On error, pass through the original buffer data
+                console.error(`Error executing plugin ${plugin.id} (${plugin.type}):`, e);
+                result = processingBuffer; // On error, pass through the original buffer data
             }
 
 


### PR DESCRIPTION
## Summary
- instrument HornResonatorPlusPlugin in the AudioWorklet to measure execution time
- log average processing time every 10 seconds

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6856a6bf5ce0832ab05670feaf7801f7