### PR TITLE
Add viscous attenuation control to Horn Resonator Plus

### DIFF
--- a/docs/plugins/resonator.md
+++ b/docs/plugins/resonator.md
@@ -62,7 +62,7 @@ Horn Resonator Plus provides superior sound quality compared to the standard Hor
 
 ### Parameters and Usage
 
-Horn Resonator Plus uses the same parameters as [Horn Resonator](#horn-resonator). Please refer to the Horn Resonator section for parameter descriptions, settings, and recommended values.
+Horn Resonator Plus uses the same parameters as [Horn Resonator](#horn-resonator) and adds **Viscous Damp (Hz)**. This control simulates frequency-dependent losses by applying a low‑pass filter to each horn segment. Use values from **1000** to **20000 Hz**; lower settings damp high frequencies more strongly.
 
 ### Usage Guidelines
 


### PR DESCRIPTION
## Summary
- extend Horn Resonator Plus with a new `va` parameter
- apply viscous attenuation filter inside the processor
- expose slider labelled *Viscous Damp*
- document the new parameter in resonator docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68583f4bd1c0832a94c15ad9ca109c63