### PR TITLE
Add blendable mouth reflection for Horn Resonator Plus

### DIFF
--- a/docs/plugins/resonator.md
+++ b/docs/plugins/resonator.md
@@ -62,7 +62,11 @@ Horn Resonator Plus provides superior sound quality compared to the standard Hor
 
 ### Parameters and Usage
 
-Horn Resonator Plus uses the same parameters as [Horn Resonator](#horn-resonator). Please refer to the Horn Resonator section for parameter descriptions, settings, and recommended values.
+Horn Resonator Plus uses the same parameters as [Horn Resonator](#horn-resonator) with one addition:
+
+- **Blend** \(0–1\) – Interpolates between the Bessel-based mouth reflection filter (0) and a simpler two‑pole approximation (1).
+
+Refer to the Horn Resonator section for descriptions of the shared controls.
 
 ### Usage Guidelines
 


### PR DESCRIPTION
## Summary
- support a `blend` parameter for Horn Resonator Plus
- compute coefficients for both Bessel-based and simple 2-pole filters
- mix between filters using new parameter in state and UI
- document the new option in the resonator plugin docs

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68584bfc5770832ab05e37a20406fb9b