### PR TITLE
Add HornResonatorPlus frequency visualizer

### DIFF
--- a/electron/ipc-handlers.js
+++ b/electron/ipc-handlers.js
@@ -496,6 +496,15 @@ function registerIpcHandlers() {
                   mainWin.loadFile('features/measurement/measurement.html');
                 }
               }
+            },
+            {
+              label: menuTemplate.settings.submenu[3].label, // HornResonatorPlus Response
+              click: () => {
+                const mainWin = constants.getMainWindow();
+                if (mainWin) {
+                  mainWin.loadFile('features/horn_resonator_plus_response.html');
+                }
+              }
             }
           ]
         },
@@ -911,6 +920,15 @@ function createMenu() {
             const mainWin = constants.getMainWindow();
             if (mainWin) {
               mainWin.loadFile('features/measurement/measurement.html');
+            }
+          }
+        },
+        {
+          label: 'HornResonatorPlus Frequency Response',
+          click: () => {
+            const mainWin = constants.getMainWindow();
+            if (mainWin) {
+              mainWin.loadFile('features/horn_resonator_plus_response.html');
             }
           }
         }

--- a/features/horn_resonator_plus_response.html
+++ b/features/horn_resonator_plus_response.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>HornResonatorPlus Frequency Response</title>
+<style>
+ body { font-family: Arial, sans-serif; background:#1a1a1a; color:#eee; }
+ .controls { margin:10px; }
+ canvas { background:#000; }
+ label { margin-right:1em; }
+</style>
+</head>
+<body>
+<h1>HornResonatorPlus Frequency Response</h1>
+<div class="controls">
+  <label>Brightness A: <input id="b1" type="range" min="0" max="1" step="0.01" value="0"></label>
+  <label>Brightness B: <input id="b2" type="range" min="0" max="1" step="0.01" value="1"></label>
+  <button id="update">Update</button>
+</div>
+<canvas id="graph" width="800" height="400"></canvas>
+<script src="../plugins/plugin-base.js"></script>
+<script src="../plugins/resonator/horn_resonator_plus.js"></script>
+<script type="module">
+import FFT from './measurement/audio-utils/fft.js';
+
+const plugin = new window.HornResonatorPlusPlugin();
+
+function computeResponse(brightness) {
+  plugin.setParameters({ bl: brightness });
+  const sr = 48000;
+  const chs = 1;
+  const bs = 128;
+  const ctx = {};
+  const params = { ...plugin.getParameters(), sampleRate: sr, channelCount: chs, blockSize: bs };
+  const total = 8192;
+  const impulse = new Float32Array(bs);
+  const response = new Float32Array(total);
+  let offset = 0;
+  for (let i = 0; i < total; i += bs) {
+    impulse.fill(0);
+    if (i === 0) impulse[0] = 1;
+    plugin.executeProcessor(ctx, impulse, params, 0);
+    response.set(impulse, offset);
+    offset += bs;
+  }
+  const fftSize = 16384;
+  const fft = new FFT(fftSize);
+  const real = new Float32Array(fftSize);
+  const imag = new Float32Array(fftSize);
+  real.set(response, 0);
+  fft.transform(real, imag, real, imag);
+  const half = fftSize / 2;
+  const result = [];
+  for (let k = 0; k < half; k++) {
+    const freq = sr * k / fftSize;
+    if (freq < 20 || freq > 20000) continue;
+    const mag = Math.sqrt(real[k] * real[k] + imag[k] * imag[k]);
+    const db = 20 * Math.log10(mag + 1e-12);
+    result.push([freq, db]);
+  }
+  return result;
+}
+
+function draw() {
+  const b1 = parseFloat(document.getElementById('b1').value);
+  const b2 = parseFloat(document.getElementById('b2').value);
+  const resp1 = computeResponse(b1);
+  const resp2 = computeResponse(b2);
+  const canvas = document.getElementById('graph');
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  const pad = {left:50,right:20,top:20,bottom:30};
+  const minF = 20, maxF = 20000;
+  const minDb = -40, maxDb = 20;
+  const w = canvas.width - pad.left - pad.right;
+  const h = canvas.height - pad.top - pad.bottom;
+  const scaleX = f => pad.left + w * (Math.log10(f) - Math.log10(minF)) / (Math.log10(maxF) - Math.log10(minF));
+  const scaleY = d => pad.top + h * (maxDb - d) / (maxDb - minDb);
+  ctx.strokeStyle = '#444';
+  for(let f=20; f<=20000; f*=10){
+    const x = scaleX(f);
+    ctx.beginPath(); ctx.moveTo(x,pad.top); ctx.lineTo(x,canvas.height-pad.bottom); ctx.stroke();
+    ctx.fillStyle='#888'; ctx.font='10px Arial'; ctx.textAlign='center';
+    ctx.fillText(f>=1000?(f/1000+'k'):f, x, canvas.height-5);
+  }
+  for(let d=minDb; d<=maxDb; d+=10){
+    const y = scaleY(d);
+    ctx.beginPath(); ctx.moveTo(pad.left,y); ctx.lineTo(canvas.width-pad.right,y); ctx.stroke();
+    ctx.fillStyle='#888'; ctx.textAlign='right'; ctx.fillText(d+'dB', pad.left-5, y+3);
+  }
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = '#ff6060';
+  ctx.beginPath();
+  resp1.forEach(([f,d],i)=>{ const x=scaleX(f), y=scaleY(d); if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); });
+  ctx.stroke();
+  ctx.strokeStyle = '#60ff60';
+  ctx.beginPath();
+  resp2.forEach(([f,d],i)=>{ const x=scaleX(f), y=scaleY(d); if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y); });
+  ctx.stroke();
+}
+
+document.getElementById('update').addEventListener('click', draw);
+draw();
+</script>
+</body>
+</html>

--- a/features/horn_resonator_plus_response.html
+++ b/features/horn_resonator_plus_response.html
@@ -3,14 +3,39 @@
 <head>
 <meta charset="UTF-8">
 <title>HornResonatorPlus Frequency Response</title>
+<link rel="stylesheet" href="../effetune.css">
+<link rel="icon" href="../images/favicon.ico" type="image/x-icon">
 <style>
  body { font-family: Arial, sans-serif; background:#1a1a1a; color:#eee; }
  .controls { margin:10px; }
  canvas { background:#000; }
  label { margin-right:1em; }
+ .back-button {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  padding: 8px 16px;
+  background-color: #2d2d2d;
+  border: 1px solid #3d3d3d;
+  color: #ffffff;
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  z-index: 100;
+ }
+ .back-button:hover { background-color: #3d3d3d; }
+ .back-button svg { margin-right: 6px; width: 16px; height: 16px; }
 </style>
 </head>
 <body>
+<button id="back-button" class="back-button">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M19 12H5M12 19l-7-7 7-7"/>
+  </svg>
+  Back to EffeTune
+</button>
 <h1>HornResonatorPlus Frequency Response</h1>
 <div class="controls">
   <label>Brightness A: <input id="b1" type="range" min="0" max="1" step="0.01" value="0"></label>
@@ -103,6 +128,32 @@ function draw() {
 
 document.getElementById('update').addEventListener('click', draw);
 draw();
+
+const backButton = document.getElementById('back-button');
+backButton.addEventListener('click', () => {
+  if (window.electronAPI) {
+    window.electronAPI.navigateToMain()
+      .catch(err => console.error('Error navigating to main page:', err));
+  } else {
+    window.location.href = '../effetune.html';
+  }
+});
+
+window.addEventListener('load', () => {
+  if (window.electronAPI) {
+    window.electronAPI.hideApplicationMenu().catch(err => {
+      console.error('Error hiding application menu:', err);
+    });
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  if (window.electronAPI) {
+    window.electronAPI.restoreDefaultMenu().catch(err => {
+      console.error('Error restoring default menu:', err);
+    });
+  }
+});
 </script>
 </body>
 </html>

--- a/js/electron/menuIntegration.js
+++ b/js/electron/menuIntegration.js
@@ -63,7 +63,8 @@ export function updateApplicationMenu(isElectron) {
         submenu: [
           { label: t('menu.settings.audioDevices') },
           { label: t('menu.settings.performanceBenchmark') },
-          { label: t('menu.settings.frequencyResponseMeasurement') }
+          { label: t('menu.settings.frequencyResponseMeasurement') },
+          { label: t('menu.settings.hornResonatorPlusResponse') }
         ]
       },
       help: {

--- a/js/locales/ar.json5
+++ b/js/locales/ar.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "أجهزة الصوت...",
   "menu.settings.performanceBenchmark": "معيار الأداء",
   "menu.settings.frequencyResponseMeasurement": "قياس الاستجابة الترددية",
+  "menu.settings.hornResonatorPlusResponse": "استجابة التردد لـHornResonatorPlus",
 
   "menu.help": "مساعدة",
   "menu.help.help": "مساعدة",

--- a/js/locales/en.json5
+++ b/js/locales/en.json5
@@ -130,6 +130,7 @@
   "menu.settings.audioDevices": "Audio Devices...",
   "menu.settings.performanceBenchmark": "Performance Benchmark",
   "menu.settings.frequencyResponseMeasurement": "Frequency Response Measurement",
+  "menu.settings.hornResonatorPlusResponse": "HornResonatorPlus Frequency Response",
 
   "menu.help": "Help",
   "menu.help.help": "Help",

--- a/js/locales/es.json5
+++ b/js/locales/es.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "Dispositivos de audio...",
   "menu.settings.performanceBenchmark": "Prueba de rendimiento",
   "menu.settings.frequencyResponseMeasurement": "Medición de respuesta en frecuencia",
+  "menu.settings.hornResonatorPlusResponse": "Respuesta de frecuencia de HornResonatorPlus",
 
   "menu.help": "Ayuda",
   "menu.help.help": "Ayuda",

--- a/js/locales/fr.json5
+++ b/js/locales/fr.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "Périphériques audio...",
   "menu.settings.performanceBenchmark": "Référence de performance",
   "menu.settings.frequencyResponseMeasurement": "Mesure de la réponse en fréquence",
+  "menu.settings.hornResonatorPlusResponse": "Réponse fréquentielle HornResonatorPlus",
 
   "menu.help": "Aide",
   "menu.help.help": "Aide",

--- a/js/locales/hi.json5
+++ b/js/locales/hi.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "ऑडियो उपकरण...",
   "menu.settings.performanceBenchmark": "प्रदर्शन बेंचमार्क",
   "menu.settings.frequencyResponseMeasurement": "फ्रीक्वेंसी रिस्पॉन्स मापन",
+  "menu.settings.hornResonatorPlusResponse": "HornResonatorPlus फ़्रीक्वेंसी रेस्पॉन्स",
 
   "menu.help": "सहायता",
   "menu.help.help": "सहायता",

--- a/js/locales/ja.json5
+++ b/js/locales/ja.json5
@@ -128,6 +128,7 @@
   "menu.settings.audioDevices": "オーディオデバイス...",
   "menu.settings.performanceBenchmark": "パフォーマンスベンチマーク",
   "menu.settings.frequencyResponseMeasurement": "周波数応答測定",
+  "menu.settings.hornResonatorPlusResponse": "HornResonatorPlus周波数特性",
 
   "menu.help": "ヘルプ",
   "menu.help.help": "ヘルプ",

--- a/js/locales/ko.json5
+++ b/js/locales/ko.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "오디오 장치...",
   "menu.settings.performanceBenchmark": "성능 벤치마크",
   "menu.settings.frequencyResponseMeasurement": "주파수 응답 측정",
+  "menu.settings.hornResonatorPlusResponse": "HornResonatorPlus 주파수 응답",
 
   "menu.help": "도움말",
   "menu.help.help": "도움말",

--- a/js/locales/pt.json5
+++ b/js/locales/pt.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "Dispositivos de Áudio...",
   "menu.settings.performanceBenchmark": "Teste de desempenho",
   "menu.settings.frequencyResponseMeasurement": "Medição da resposta em frequência",
+  "menu.settings.hornResonatorPlusResponse": "Resposta de frequência do HornResonatorPlus",
 
   "menu.help": "Ajuda",
   "menu.help.help": "Ajuda",

--- a/js/locales/ru.json5
+++ b/js/locales/ru.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "Аудиоустройства...",
   "menu.settings.performanceBenchmark": "Тест производительности",
   "menu.settings.frequencyResponseMeasurement": "Измерение частотной характеристики",
+  "menu.settings.hornResonatorPlusResponse": "Частотная характеристика HornResonatorPlus",
 
   "menu.help": "Помощь",
   "menu.help.help": "Помощь",

--- a/js/locales/zh.json5
+++ b/js/locales/zh.json5
@@ -129,6 +129,7 @@
   "menu.settings.audioDevices": "音频设备…",
   "menu.settings.performanceBenchmark": "性能基准测试",
   "menu.settings.frequencyResponseMeasurement": "频率响应测量",
+  "menu.settings.hornResonatorPlusResponse": "HornResonatorPlus频率响应",
 
   "menu.help": "帮助",
   "menu.help.help": "帮助",

--- a/plugins/resonator/horn_resonator_plus.js
+++ b/plugins/resonator/horn_resonator_plus.js
@@ -521,6 +521,14 @@ class HornResonatorPlusPlugin extends PluginBase {
         c.appendChild(this.createParameterControl('Output Gain', -36, 36, 0.1, this.wg, (v) => this.setParameters({ wg: v }), 'dB'));
         c.appendChild(this.createParameterControl('Brightness', 0, 1, 0.01, this.bl, (v) => this.setParameters({ bl: v })));
 
+        const viewBtn = document.createElement('button');
+        viewBtn.textContent = 'View Response Graph';
+        viewBtn.style.marginTop = '8px';
+        viewBtn.addEventListener('click', () => {
+            window.location.href = 'features/horn_resonator_plus_response.html';
+        });
+        c.appendChild(viewBtn);
+
         return c;
     }
 }


### PR DESCRIPTION
## Summary
- add a frequency response visualizer for HornResonatorPlus

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685aee28e3ac832a898cac88a26d8d21