### PR TITLE
Add GC event monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,12 @@ For optimal performance with nonlinear effects, it is recommended to use EffeTun
 Want to create your own audio plugins? Check out our [Plugin Development Guide](docs/plugin-development.md).
 Want to build a desktop app? Check out our [Build Guide](build.md).
 
+### Debugging Garbage Collection
+
+When running the desktop version, EffeTune now logs Node.js garbage collection events.
+These events appear briefly in the bottom-right corner of the window and in the
+developer console. Use this to verify whether audio glitches coincide with GC pauses.
+
 ## Links
 
 [Version History](docs/version-history.md)

--- a/effetune.html
+++ b/effetune.html
@@ -75,6 +75,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsmediatags/3.9.5/jsmediatags.min.js" integrity="sha384-JpTt7qxVx1X/pHeYiCfqFdKRu2HF1MBGr1kEXtbNIGwwryGWMbbW78onU3bdkAHZ" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script type="module" src="js/app.js"></script>
+    <div id="gcLog" style="position: fixed; bottom: 10px; right: 10px; background: rgba(0,0,0,0.6); color: #0f0; padding: 4px 8px; font-size: 11px; z-index: 10000; pointer-events: none; display: none;"></div>
     <div style="text-align: center; margin-top: 20px; color: #666; font-size: 12px;">
         EffeTune version <span id="app-version"></span> (C) Frieve 2025
     </div>

--- a/electron/gc-monitor.js
+++ b/electron/gc-monitor.js
@@ -1,0 +1,37 @@
+const { PerformanceObserver, constants: perfConstants } = require('perf_hooks');
+
+const gcKinds = {
+  [perfConstants.NODE_PERFORMANCE_GC_MINOR]: 'minor',
+  [perfConstants.NODE_PERFORMANCE_GC_MAJOR]: 'major',
+  [perfConstants.NODE_PERFORMANCE_GC_INCREMENTAL]: 'incremental',
+  [perfConstants.NODE_PERFORMANCE_GC_WEAKCB]: 'weakcb'
+};
+
+let mainWindow = null;
+
+function setMainWindow(win) {
+  mainWindow = win;
+}
+
+function startMonitoring() {
+  const obs = new PerformanceObserver((list) => {
+    list.getEntries().forEach((entry) => {
+      const kind = gcKinds[entry.kind] || 'unknown';
+      const data = { kind, duration: entry.duration };
+      console.log(`GC ${kind}: ${entry.duration.toFixed(2)} ms`);
+      if (mainWindow && mainWindow.webContents) {
+        mainWindow.webContents.send('gc-event', data);
+      }
+    });
+  });
+  try {
+    obs.observe({ entryTypes: ['gc'], buffered: false });
+  } catch (err) {
+    console.warn('GC monitoring not supported:', err.message || err);
+  }
+}
+
+module.exports = {
+  startMonitoring,
+  setMainWindow
+};

--- a/electron/main.js
+++ b/electron/main.js
@@ -7,6 +7,7 @@ const constants = require('./constants');
 const windowState = require('./window-state');
 const ipcHandlers = require('./ipc-handlers');
 const fileHandlers = require('./file-handlers');
+const gcMonitor = require('./gc-monitor');
 
 // Get app version from package.json
 const packageJson = require('../package.json');
@@ -67,6 +68,7 @@ function createWindow() {
   constants.setMainWindow(mainWindow);
   ipcHandlers.setMainWindow(mainWindow);
   fileHandlers.setMainWindow(mainWindow);
+  gcMonitor.setMainWindow(mainWindow);
   
   // Enable file drag and drop for the window
   mainWindow.webContents.session.on('will-download', (event, item, webContents) => {
@@ -479,6 +481,7 @@ function createWindow() {
   
   mainWindow.on('closed', () => {
     constants.setMainWindow(null);
+    gcMonitor.setMainWindow(null);
   });
 }
 
@@ -708,6 +711,9 @@ function initializeApp() {
   
   // Create the main window
   createWindow();
+
+  // Start monitoring garbage collection events
+  gcMonitor.startMonitoring();
   
   // Register IPC handlers
   ipcHandlers.registerIpcHandlers();

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -113,6 +113,11 @@ contextBridge.exposeInMainWorld(
     // Signal that the renderer is ready to receive music files
     signalReadyForMusicFiles: () => {
       ipcRenderer.send('renderer-ready-for-music-files');
+    },
+
+    // Receive garbage collection events
+    onGCEvent: (callback) => {
+      ipcRenderer.on('gc-event', (_, data) => callback(data));
     }
   }
 );

--- a/js/app.js
+++ b/js/app.js
@@ -7,6 +7,22 @@ import { applySerializedState } from './utils/serialization-utils.js';
 // Make electronIntegration globally accessible first
 window.electronIntegration = electronIntegration;
 
+// Display garbage collection events when running in Electron
+const gcLogElement = document.getElementById('gcLog');
+if (gcLogElement && window.electronAPI &&
+    window.electronIntegration && window.electronIntegration.isElectron) {
+    window.electronAPI.onGCEvent(({ kind, duration }) => {
+        gcLogElement.style.display = 'block';
+        gcLogElement.textContent = `GC ${kind} - ${duration.toFixed(2)} ms`;
+        if (gcLogElement._timeout) {
+            clearTimeout(gcLogElement._timeout);
+        }
+        gcLogElement._timeout = setTimeout(() => {
+            gcLogElement.style.display = 'none';
+        }, 2000);
+    });
+}
+
 // Store the latest pipeline state in memory
 let latestPipelineState = null;
 


### PR DESCRIPTION
## Summary
- monitor Node.js garbage collection in the main process
- expose GC events to the renderer through the preload script
- display GC events briefly on screen
- document GC debugging in README

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685ed633a2a0832ab972a1027ff1b806