### PR TITLE
Add GC event monitor

### DIFF
--- a/effetune.html
+++ b/effetune.html
@@ -75,6 +75,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js" integrity="sha512-XMVd28F1oH/O71fzwBnV7HucLxVwtxf26XV8P4wPk26EDxuGZ91N8bsOttmnomcCD3CS5ZMRL50H0GgOHvegtg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsmediatags/3.9.5/jsmediatags.min.js" integrity="sha384-JpTt7qxVx1X/pHeYiCfqFdKRu2HF1MBGr1kEXtbNIGwwryGWMbbW78onU3bdkAHZ" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script type="module" src="js/app.js"></script>
+    <script type="module" src="js/gc-visualizer.js"></script>
     <div style="text-align: center; margin-top: 20px; color: #666; font-size: 12px;">
         EffeTune version <span id="app-version"></span> (C) Frieve 2025
     </div>

--- a/electron/gc-monitor.js
+++ b/electron/gc-monitor.js
@@ -1,0 +1,25 @@
+const { PerformanceObserver } = require('perf_hooks');
+const constants = require('./constants');
+
+let observer = null;
+
+function startMonitoring() {
+  if (observer) {
+    return;
+  }
+  observer = new PerformanceObserver((list) => {
+    const entry = list.getEntries()[0];
+    const mainWindow = constants.getMainWindow();
+    const data = {
+      kind: entry.detail ? entry.detail.kind : 0,
+      duration: entry.duration,
+    };
+    if (mainWindow && mainWindow.webContents) {
+      mainWindow.webContents.send('gc-event', data);
+    }
+    console.log(`GC event: kind=${data.kind} duration=${data.duration.toFixed(2)}ms`);
+  });
+  observer.observe({ entryTypes: ['gc'] });
+}
+
+module.exports = { startMonitoring };

--- a/electron/main.js
+++ b/electron/main.js
@@ -7,6 +7,7 @@ const constants = require('./constants');
 const windowState = require('./window-state');
 const ipcHandlers = require('./ipc-handlers');
 const fileHandlers = require('./file-handlers');
+const gcMonitor = require('./gc-monitor');
 
 // Get app version from package.json
 const packageJson = require('../package.json');
@@ -67,6 +68,7 @@ function createWindow() {
   constants.setMainWindow(mainWindow);
   ipcHandlers.setMainWindow(mainWindow);
   fileHandlers.setMainWindow(mainWindow);
+  gcMonitor.startMonitoring();
   
   // Enable file drag and drop for the window
   mainWindow.webContents.session.on('will-download', (event, item, webContents) => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -109,7 +109,12 @@ contextBridge.exposeInMainWorld(
     onAudioFilesDropped: (callback) => {
       ipcRenderer.on('audio-files-dropped', (event, filePaths) => callback(filePaths));
     },
-    
+
+    // Listen for garbage collection events
+    onGcEvent: (callback) => {
+      ipcRenderer.on('gc-event', (_, data) => callback(data));
+    },
+
     // Signal that the renderer is ready to receive music files
     signalReadyForMusicFiles: () => {
       ipcRenderer.send('renderer-ready-for-music-files');

--- a/js/gc-visualizer.js
+++ b/js/gc-visualizer.js
@@ -1,0 +1,28 @@
+// Simple GC visualization overlay for Electron
+if (window.electronAPI && window.electronIntegration && window.electronIntegration.isElectron) {
+  const overlay = document.createElement('div');
+  overlay.className = 'gc-overlay';
+  overlay.style.position = 'fixed';
+  overlay.style.bottom = '10px';
+  overlay.style.right = '10px';
+  overlay.style.background = 'rgba(0,0,0,0.7)';
+  overlay.style.color = '#0f0';
+  overlay.style.fontSize = '12px';
+  overlay.style.fontFamily = 'monospace';
+  overlay.style.padding = '4px 6px';
+  overlay.style.zIndex = '2000';
+  overlay.style.pointerEvents = 'none';
+  overlay.textContent = 'Waiting for GC...';
+  document.addEventListener('DOMContentLoaded', () => {
+    document.body.appendChild(overlay);
+  });
+
+  window.electronAPI.onGcEvent((data) => {
+    overlay.textContent = `GC kind=${data.kind} duration=${data.duration.toFixed(1)}ms`;
+    overlay.style.opacity = '1';
+    clearTimeout(overlay._hideTimer);
+    overlay._hideTimer = setTimeout(() => {
+      overlay.style.opacity = '0.4';
+    }, 2000);
+  });
+}


### PR DESCRIPTION
## Summary
- monitor garbage collection events in Electron main process
- expose GC events to renderer via context bridge
- visualize GC activity with a simple overlay

## Testing
- `node -e "require('./electron/gc-monitor').startMonitoring(); setInterval(()=>{Array(1e6).fill(0);},100); setTimeout(()=>{process.exit(0)},1000);"`

------
https://chatgpt.com/codex/tasks/task_b_685ed633a2a0832ab972a1027ff1b806