### PR TITLE
Add GC monitoring view

### DIFF
--- a/effetune.html
+++ b/effetune.html
@@ -16,6 +16,7 @@
         <div class="header-buttons">
             <button class="header-button open-music-button" id="openMusicButton" title="Open music files"><img src="images/open_button.png" width="16" height="16"></button>
             <button class="header-button reset-button" id="resetButton">Reset Audio</button>
+            <button class="header-button" id="gcMonitorButton" title="Open GC Monitor">GC Monitor</button>
         </div>
         <div class="subtitle-container">
             <button class="header-button sidebar-button" id="sidebarButton" title="Toggle plugin list"><img src="images/sidebar.png" width="16" height="16"></button>

--- a/electron/ipc-handlers.js
+++ b/electron/ipc-handlers.js
@@ -496,6 +496,15 @@ function registerIpcHandlers() {
                   mainWin.loadFile('features/measurement/measurement.html');
                 }
               }
+            },
+            {
+              label: menuTemplate.settings.submenu[3].label, // GC Monitor
+              click: () => {
+                const mainWin = constants.getMainWindow();
+                if (mainWin) {
+                  mainWin.loadFile('features/gc-monitor.html');
+                }
+              }
             }
           ]
         },
@@ -911,6 +920,15 @@ function createMenu() {
             const mainWin = constants.getMainWindow();
             if (mainWin) {
               mainWin.loadFile('features/measurement/measurement.html');
+            }
+          }
+        },
+        {
+          label: 'GC Monitor',
+          click: () => {
+            const mainWin = constants.getMainWindow();
+            if (mainWin) {
+              mainWin.loadFile('features/gc-monitor.html');
             }
           }
         }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -226,3 +226,37 @@ document.addEventListener('DOMContentLoaded', () => {
 // Note: We're not adding drag and drop event listeners here anymore
 // to avoid conflicts with the existing drag and drop functionality
 // The existing functionality is implemented in main.js
+
+// ============================================================================
+// GC Monitor API
+// ============================================================================
+const { PerformanceObserver } = require('perf_hooks');
+let gcObserver = null;
+
+function startGCMonitor() {
+  if (!gcObserver) {
+    try {
+      gcObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          window.postMessage({ type: 'gc-event', entry }, '*');
+        }
+      });
+      gcObserver.observe({ entryTypes: ['gc'], buffered: false });
+    } catch (err) {
+      console.error('Failed to start GC monitor:', err);
+    }
+  }
+}
+
+function stopGCMonitor() {
+  if (gcObserver) {
+    gcObserver.disconnect();
+    gcObserver = null;
+  }
+}
+
+contextBridge.exposeInMainWorld('gcMonitor', {
+  start: startGCMonitor,
+  stop: stopGCMonitor
+});
+

--- a/features/gc-monitor.html
+++ b/features/gc-monitor.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>GC Monitor</title>
+    <link rel="stylesheet" href="../effetune.css">
+    <link rel="icon" href="../images/favicon.ico" type="image/x-icon">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.1/chart.umd.min.js"></script>
+    <style>
+        body {
+            background: #1e1e1e;
+            color: #fff;
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        #gcChart {
+            width: 100%;
+            height: 300px;
+        }
+        .back-button {
+            margin-bottom: 10px;
+        }
+    </style>
+</head>
+<body>
+    <button id="back-button" class="back-button">Back to EffeTune</button>
+    <h1>Garbage Collection Monitor</h1>
+    <canvas id="gcChart"></canvas>
+    <div id="log" style="white-space: pre-line; font-family: monospace; margin-top: 10px;"></div>
+    <script>
+        const ctx = document.getElementById('gcChart').getContext('2d');
+        const startTime = Date.now();
+        const data = {
+            datasets: [
+                {
+                    label: 'Used JS Heap (MB)',
+                    data: [],
+                    borderColor: 'rgb(75, 192, 192)',
+                    tension: 0.1,
+                    fill: false
+                },
+                {
+                    label: 'GC Event',
+                    data: [],
+                    type: 'scatter',
+                    backgroundColor: 'red',
+                    pointRadius: 4
+                }
+            ]
+        };
+        const chart = new Chart(ctx, {
+            type: 'line',
+            data: data,
+            options: {
+                animation: false,
+                scales: {
+                    x: {
+                        type: 'linear',
+                        title: { display: true, text: 'Time (s)', color: 'white' }
+                    },
+                    y: { beginAtZero: true }
+                },
+                plugins: { legend: { labels: { color: 'white' } } }
+            }
+        });
+
+        function updateMemory() {
+            if (performance && performance.memory) {
+                const usedMB = performance.memory.usedJSHeapSize / 1048576;
+                const t = (Date.now() - startTime) / 1000;
+                chart.data.datasets[0].data.push({ x: t, y: usedMB });
+                chart.update('none');
+            }
+        }
+        setInterval(updateMemory, 1000);
+
+        window.addEventListener('message', (event) => {
+            if (event.data && event.data.type === 'gc-event') {
+                const entry = event.data.entry;
+                const usedMB = performance.memory ? performance.memory.usedJSHeapSize / 1048576 : 0;
+                const t = (Date.now() - startTime) / 1000;
+                chart.data.datasets[1].data.push({ x: t, y: usedMB });
+                const logEl = document.getElementById('log');
+                logEl.textContent += `GC ${entry.detail.kind} at ${entry.startTime.toFixed(1)} ms, duration ${entry.duration.toFixed(3)} ms\n`;
+                chart.update('none');
+            }
+        });
+
+        const backBtn = document.getElementById('back-button');
+        backBtn.addEventListener('click', () => {
+            if (window.electronAPI) {
+                window.electronAPI.navigateToMain();
+            } else {
+                window.location.href = '../effetune.html';
+            }
+        });
+
+        window.addEventListener('load', () => {
+            if (window.gcMonitor) window.gcMonitor.start();
+            if (window.electronAPI) window.electronAPI.hideApplicationMenu();
+        });
+
+        window.addEventListener('beforeunload', () => {
+            if (window.gcMonitor) window.gcMonitor.stop();
+            if (window.electronAPI) window.electronAPI.restoreDefaultMenu();
+        });
+    </script>
+</body>
+</html>

--- a/js/electron/menuIntegration.js
+++ b/js/electron/menuIntegration.js
@@ -63,7 +63,8 @@ export function updateApplicationMenu(isElectron) {
         submenu: [
           { label: t('menu.settings.audioDevices') },
           { label: t('menu.settings.performanceBenchmark') },
-          { label: t('menu.settings.frequencyResponseMeasurement') }
+          { label: t('menu.settings.frequencyResponseMeasurement') },
+          { label: t('menu.settings.gcMonitor') }
         ]
       },
       help: {

--- a/js/locales/ar.json5
+++ b/js/locales/ar.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "إعادة تعيين الصوت",
   "ui.configAudioButton": "إعداد الصوت",
   "ui.shareButton": "مشاركة",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "اسحب هذا التأثير لإضافته في الموقع المطلوب بسلسلة التأثيرات.\nأو انقر نقراً مزدوجاً لإضافته.",
   "ui.dragPluginsHere": "اسحب التأثيرات هنا لبناء سلسلة تأثيرات",
   "ui.effectsAvailable": "{count} تأثيرات متاحة",
@@ -62,6 +63,7 @@
   "ui.title.paste": "لصق المؤثرات",
   "ui.title.savePreset": "حفظ الإعداد المسبق",
   "ui.title.deletePreset": "حذف الإعداد المسبق",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "مشاركة خط المعالجة",
   "ui.title.decreaseColumns": "تقليل الأعمدة",
   "ui.title.increaseColumns": "زيادة الأعمدة",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "أجهزة الصوت...",
   "menu.settings.performanceBenchmark": "معيار الأداء",
   "menu.settings.frequencyResponseMeasurement": "قياس الاستجابة الترددية",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "مساعدة",
   "menu.help.help": "مساعدة",

--- a/js/locales/en.json5
+++ b/js/locales/en.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "Reset Audio",
   "ui.configAudioButton": "Config Audio",
   "ui.shareButton": "Share",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "Drag this effect to add it at your desired position in the Effect Pipeline.\nAlternatively, you can double-click this effect to add it to the Effect Pipeline.",
   "ui.dragPluginsHere": "Drag effects here to build your effect pipeline",
   "ui.effectsAvailable": "{count} effects available",
@@ -62,6 +63,7 @@
   "ui.title.paste": "Paste effects",
   "ui.title.savePreset": "Save preset",
   "ui.title.deletePreset": "Delete preset",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "Share pipeline",
   "ui.title.decreaseColumns": "Decrease columns",
   "ui.title.increaseColumns": "Increase columns",
@@ -130,6 +132,7 @@
   "menu.settings.audioDevices": "Audio Devices...",
   "menu.settings.performanceBenchmark": "Performance Benchmark",
   "menu.settings.frequencyResponseMeasurement": "Frequency Response Measurement",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "Help",
   "menu.help.help": "Help",

--- a/js/locales/es.json5
+++ b/js/locales/es.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "Reiniciar audio",
   "ui.configAudioButton": "Configurar audio",
   "ui.shareButton": "Compartir",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "Arrastra este efecto para colocarlo en la posición deseada de la cadena de efectos.\nO haz doble clic para añadirlo.",
   "ui.dragPluginsHere": "Arrastra efectos aquí para crear tu cadena de efectos",
   "ui.effectsAvailable": "{count} efectos disponibles",
@@ -62,6 +63,7 @@
   "ui.title.paste": "Pegar efectos",
   "ui.title.savePreset": "Guardar preset",
   "ui.title.deletePreset": "Eliminar preset",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "Compartir pipeline",
   "ui.title.decreaseColumns": "Disminuir columnas",
   "ui.title.increaseColumns": "Aumentar columnas",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "Dispositivos de audio...",
   "menu.settings.performanceBenchmark": "Prueba de rendimiento",
   "menu.settings.frequencyResponseMeasurement": "Medición de respuesta en frecuencia",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "Ayuda",
   "menu.help.help": "Ayuda",

--- a/js/locales/fr.json5
+++ b/js/locales/fr.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "Réinitialiser l'audio",
   "ui.configAudioButton": "Configurer l'audio",
   "ui.shareButton": "Partager",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "Faites glisser cet effet pour l'ajouter à la position souhaitée dans la chaîne d'effets.\nOu double-cliquez pour l'ajouter.",
   "ui.dragPluginsHere": "Faites glisser les effets ici pour créer votre chaîne d'effets",
   "ui.effectsAvailable": "{count} effets disponibles",
@@ -62,6 +63,7 @@
   "ui.title.paste": "Coller les effets",
   "ui.title.savePreset": "Enregistrer le preset",
   "ui.title.deletePreset": "Supprimer le preset",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "Partager la chaîne",
   "ui.title.decreaseColumns": "Réduire le nombre de colonnes",
   "ui.title.increaseColumns": "Augmenter le nombre de colonnes",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "Périphériques audio...",
   "menu.settings.performanceBenchmark": "Référence de performance",
   "menu.settings.frequencyResponseMeasurement": "Mesure de la réponse en fréquence",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "Aide",
   "menu.help.help": "Aide",

--- a/js/locales/hi.json5
+++ b/js/locales/hi.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "ऑडियो रीसेट करें",
   "ui.configAudioButton": "ऑडियो विन्यास",
   "ui.shareButton": "साझा करें",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "इफेक्ट जोड़ने के लिए इसे खींचें अपनी इच्छित स्थिति पर।\nया इसे डबल-क्लिक करें।",
   "ui.dragPluginsHere": "अपनी प्रभाव पाइपलाइन बनाने के लिए प्रभावों को यहां खींचें",
   "ui.effectsAvailable": "{count} प्रभाव उपलब्ध",
@@ -62,6 +63,7 @@
   "ui.title.paste": "प्रभाव पेस्ट करें",
   "ui.title.savePreset": "प्रीसेट सहेजें",
   "ui.title.deletePreset": "प्रीसेट हटाएँ",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "पाइपलाइन साझा करें",
   "ui.title.decreaseColumns": "कॉलम घटाएँ",
   "ui.title.increaseColumns": "कॉलम बढ़ाएँ",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "ऑडियो उपकरण...",
   "menu.settings.performanceBenchmark": "प्रदर्शन बेंचमार्क",
   "menu.settings.frequencyResponseMeasurement": "फ्रीक्वेंसी रिस्पॉन्स मापन",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "सहायता",
   "menu.help.help": "सहायता",

--- a/js/locales/ja.json5
+++ b/js/locales/ja.json5
@@ -41,6 +41,7 @@
   "ui.resetButton": "オーディオをリセット",
   "ui.configAudioButton": "オーディオ設定",
   "ui.shareButton": "共有",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "エフェクトをドラッグして、エフェクトパイプライン内の希望する位置に追加してください。\nまたは、エフェクトをダブルクリックしてエフェクトパイプラインに追加できます。",
   "ui.dragPluginsHere": "エフェクトをここにドラッグしてエフェクトパイプラインを構築",
   "ui.effectsAvailable": "{count}種類のエフェクトが利用可能です",
@@ -61,6 +62,7 @@
   "ui.title.paste": "エフェクトを貼り付け",
   "ui.title.savePreset": "プリセットを保存",
   "ui.title.deletePreset": "プリセットを削除",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "パイプラインを共有",
   "ui.title.decreaseColumns": "列を減らす",
   "ui.title.increaseColumns": "列を増やす",
@@ -128,6 +130,7 @@
   "menu.settings.audioDevices": "オーディオデバイス...",
   "menu.settings.performanceBenchmark": "パフォーマンスベンチマーク",
   "menu.settings.frequencyResponseMeasurement": "周波数応答測定",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "ヘルプ",
   "menu.help.help": "ヘルプ",

--- a/js/locales/ko.json5
+++ b/js/locales/ko.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "오디오 재설정",
   "ui.configAudioButton": "오디오 설정",
   "ui.shareButton": "공유",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "이 효과를 원하는 위치로 드래그하여 체인에 추가하세요.\n또는 더블클릭하여 추가할 수 있습니다.",
   "ui.dragPluginsHere": "효과 파이프라인을 구축하려면 여기로 효과를 끌어다 놓으세요",
   "ui.effectsAvailable": "{count}개의 효과 사용 가능",
@@ -62,6 +63,7 @@
   "ui.title.paste": "이펙트 붙여넣기",
   "ui.title.savePreset": "프리셋 저장",
   "ui.title.deletePreset": "프리셋 삭제",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "파이프라인 공유",
   "ui.title.decreaseColumns": "열 축소",
   "ui.title.increaseColumns": "열 확대",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "오디오 장치...",
   "menu.settings.performanceBenchmark": "성능 벤치마크",
   "menu.settings.frequencyResponseMeasurement": "주파수 응답 측정",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "도움말",
   "menu.help.help": "도움말",

--- a/js/locales/pt.json5
+++ b/js/locales/pt.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "Redefinir Áudio",
   "ui.configAudioButton": "Configurar Áudio",
   "ui.shareButton": "Compartilhar",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "Arraste este efeito para a posição desejada na cadeia de efeitos.\nOu clique duas vezes para adicioná-lo.",
   "ui.dragPluginsHere": "Arraste efeitos aqui para montar sua cadeia de efeitos",
   "ui.effectsAvailable": "{count} efeitos disponíveis",
@@ -62,6 +63,7 @@
   "ui.title.paste": "Colar efeitos",
   "ui.title.savePreset": "Salvar preset",
   "ui.title.deletePreset": "Excluir preset",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "Compartilhar pipeline",
   "ui.title.decreaseColumns": "Diminuir colunas",
   "ui.title.increaseColumns": "Aumentar colunas",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "Dispositivos de Áudio...",
   "menu.settings.performanceBenchmark": "Teste de desempenho",
   "menu.settings.frequencyResponseMeasurement": "Medição da resposta em frequência",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "Ajuda",
   "menu.help.help": "Ajuda",

--- a/js/locales/ru.json5
+++ b/js/locales/ru.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "Сбросить аудио",
   "ui.configAudioButton": "Настроить аудио",
   "ui.shareButton": "Поделиться",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "Перетащите этот эффект в нужное место в цепочке эффектов.\nИли дважды кликните, чтобы добавить его.",
   "ui.dragPluginsHere": "Перетащите эффекты сюда, чтобы создать свой конвейер эффектов",
   "ui.effectsAvailable": "{count} доступных эффектов",
@@ -62,6 +63,7 @@
   "ui.title.paste": "Вставить эффекты",
   "ui.title.savePreset": "Сохранить пресет",
   "ui.title.deletePreset": "Удалить пресет",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "Поделиться цепочкой",
   "ui.title.decreaseColumns": "Уменьшить число колонок",
   "ui.title.increaseColumns": "Увеличить число колонок",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "Аудиоустройства...",
   "menu.settings.performanceBenchmark": "Тест производительности",
   "menu.settings.frequencyResponseMeasurement": "Измерение частотной характеристики",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "Помощь",
   "menu.help.help": "Помощь",

--- a/js/locales/zh.json5
+++ b/js/locales/zh.json5
@@ -42,6 +42,7 @@
   "ui.resetButton": "重置音频",
   "ui.configAudioButton": "配置音频",
   "ui.shareButton": "分享",
+  "ui.gcMonitorButton": "GC Monitor",
   "ui.dragEffectMessage": "拖动此效果至效果管线的所需位置，或双击以添加。",
   "ui.dragPluginsHere": "将效果拖到此处以构建效果管道",
   "ui.effectsAvailable": "{count} 个效果可用",
@@ -62,6 +63,7 @@
   "ui.title.paste": "粘贴效果",
   "ui.title.savePreset": "保存预设",
   "ui.title.deletePreset": "删除预设",
+  "ui.title.gcMonitor": "Open GC monitor",
   "ui.title.sharePipeline": "共享处理链",
   "ui.title.decreaseColumns": "减少列数",
   "ui.title.increaseColumns": "增加列数",
@@ -129,6 +131,7 @@
   "menu.settings.audioDevices": "音频设备…",
   "menu.settings.performanceBenchmark": "性能基准测试",
   "menu.settings.frequencyResponseMeasurement": "频率响应测量",
+  "menu.settings.gcMonitor": "GC Monitor",
 
   "menu.help": "帮助",
   "menu.help.help": "帮助",

--- a/js/ui-manager.js
+++ b/js/ui-manager.js
@@ -49,6 +49,7 @@ export class UIManager {
         this.initShareButton();
         this.initPresetManagement();
         this.initOpenMusicButton();
+        this.initGCMonitorButton();
 
         // Initialize clipboard buttons
         this.undoButton = document.getElementById('undoButton');
@@ -557,6 +558,12 @@ export class UIManager {
             openMusicButton.title = this.t('ui.title.openMusic');
         }
 
+        const gcMonitorButton = document.getElementById('gcMonitorButton');
+        if (gcMonitorButton) {
+            gcMonitorButton.textContent = this.t('ui.gcMonitorButton');
+            gcMonitorButton.title = this.t('ui.title.gcMonitor');
+        }
+
         const sidebarButton = document.getElementById('sidebarButton');
         if (sidebarButton) {
             sidebarButton.title = this.t('ui.title.sidebar');
@@ -932,6 +939,21 @@ export class UIManager {
                         // Failed to read clipboard
                         this.setError('error.failedToReadClipboard', true);
                     });
+            });
+        }
+    }
+
+    /**
+     * Initialize GC monitor button
+     */
+    initGCMonitorButton() {
+        const btn = document.getElementById('gcMonitorButton');
+        if (btn) {
+            btn.addEventListener('click', () => {
+                if (window.electronAPI) {
+                    window.electronAPI.hideApplicationMenu().catch(() => {});
+                }
+                window.location.href = 'features/gc-monitor.html';
             });
         }
     }


### PR DESCRIPTION
## Summary
- add a GC monitor page that graphs heap usage and GC events
- expose perf_hooks observer in preload for GC events
- add menu entry and toolbar button to open the GC monitor
- wire up GC monitor button in UI manager
- update translations for the new button and menu entry

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685ed9932700832aadd8d1846628be04