### PR TITLE
Add Memory Monitor plugin

### DIFF
--- a/docs/plugins/analyzer.md
+++ b/docs/plugins/analyzer.md
@@ -5,6 +5,7 @@ A collection of plugins that let you see your music in fascinating ways. These v
 ## Plugin List
 
 - [Level Meter](#level-meter) - Shows how loud the music is playing
+- [Memory Monitor](#memory-monitor) - Visualizes memory usage and garbage collection
 - [Oscilloscope](#oscilloscope) - Shows real-time waveform visualization
 - [Spectrogram](#spectrogram) - Creates beautiful visual patterns from your music
 - [Spectrum Analyzer](#spectrum-analyzer) - Shows the different frequencies in your music
@@ -20,6 +21,12 @@ A visual display that shows you how loud your music is playing in real-time. It 
 - Red marker shows the highest recent level
 - Red warning at the top means the volume might be too loud
 - For comfortable listening, try to keep levels in the middle range
+
+## Memory Monitor
+
+A diagnostic tool that tracks JavaScript heap usage over time. It displays a
+scrolling heatmap of memory consumption and marks sudden drops that may indicate
+garbage collection.
 
 ## Oscilloscope
 

--- a/plugins/analyzer/memory_monitor.css
+++ b/plugins/analyzer/memory_monitor.css
@@ -1,0 +1,7 @@
+.memory-monitor canvas {
+    background-color: #1a1a1a;
+}
+
+.memory-monitor .graph-container {
+    margin-top: 20px;
+}

--- a/plugins/analyzer/memory_monitor.js
+++ b/plugins/analyzer/memory_monitor.js
@@ -1,0 +1,120 @@
+class MemoryMonitorPlugin extends PluginBase {
+    constructor() {
+        super('Memory Monitor', 'Visualize JS heap usage over time');
+        this.samples = [];
+        this.maxSamples = 300; // Number of columns in the heatmap
+        this.intervalMs = 1000; // Sampling interval
+        this.maxMemory = 0;
+        this.gcIndices = [];
+        this.timer = null;
+        this.canvas = null;
+        this.ctx = null;
+        this.observer = null;
+
+        // Register a pass-through processor
+        this.registerProcessor(`
+            return data;
+        `);
+    }
+
+    // Return parameters (none beyond base)
+    getParameters() {
+        return {
+            ...super.getParameters()
+        };
+    }
+
+    setParameters(params) {
+        super.setParameters(params);
+    }
+
+    createUI() {
+        const container = document.createElement('div');
+        container.className = 'plugin-parameter-ui memory-monitor';
+
+        const graphContainer = document.createElement('div');
+        graphContainer.className = 'graph-container';
+
+        this.canvas = document.createElement('canvas');
+        this.canvas.width = this.maxSamples;
+        this.canvas.height = 80;
+        this.ctx = this.canvas.getContext('2d');
+        graphContainer.appendChild(this.canvas);
+
+        container.appendChild(graphContainer);
+
+        if (this.observer == null) {
+            this.observer = new IntersectionObserver(entries => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        this.start();
+                    } else {
+                        this.stop();
+                    }
+                });
+            });
+        }
+        this.observer.observe(this.canvas);
+
+        return container;
+    }
+
+    start() {
+        if (this.timer) return;
+        this.timer = setInterval(() => {
+            let used = 0;
+            if (performance && performance.memory) {
+                used = performance.memory.usedJSHeapSize / (1024 * 1024);
+            }
+            this.samples.push(used);
+            if (this.samples.length > this.maxSamples) {
+                this.samples.shift();
+                this.gcIndices = this.gcIndices.map(i => i - 1).filter(i => i >= 0);
+            }
+            const len = this.samples.length;
+            if (len >= 2 && this.samples[len - 2] - used > 1) {
+                this.gcIndices.push(len - 1);
+            }
+            this.maxMemory = Math.max(this.maxMemory, used);
+            this.draw();
+        }, this.intervalMs);
+    }
+
+    stop() {
+        if (this.timer) {
+            clearInterval(this.timer);
+            this.timer = null;
+        }
+    }
+
+    draw() {
+        if (!this.ctx) return;
+        const { ctx, canvas } = this;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        const maxMem = this.maxMemory || 1;
+        for (let i = 0; i < this.samples.length; i++) {
+            const mem = this.samples[i];
+            const intensity = mem / maxMem;
+            const hue = (1 - intensity) * 120; // Green to red
+            const barHeight = (mem / maxMem) * canvas.height;
+            ctx.fillStyle = `hsl(${hue},100%,50%)`;
+            ctx.fillRect(i, canvas.height - barHeight, 1, barHeight);
+            if (this.gcIndices.includes(i)) {
+                ctx.fillStyle = 'blue';
+                ctx.fillRect(i, 0, 1, canvas.height);
+            }
+        }
+    }
+
+    cleanup() {
+        this.stop();
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.MemoryMonitorPlugin = MemoryMonitorPlugin;
+}

--- a/plugins/plugins.txt
+++ b/plugins/plugins.txt
@@ -20,6 +20,7 @@ Control: Control tools
 # Plugins are sorted by category, then alphabetically by path
 [plugins]
 analyzer/level_meter: Level Meter | Analyzer | LevelMeterPlugin | css
+analyzer/memory_monitor: Memory Monitor | Analyzer | MemoryMonitorPlugin | css
 analyzer/oscilloscope: Oscilloscope | Analyzer | OscilloscopePlugin | css
 analyzer/spectrogram: Spectrogram | Analyzer | SpectrogramPlugin | css
 analyzer/spectrum_analyzer: Spectrum Analyzer | Analyzer | SpectrumAnalyzerPlugin | css


### PR DESCRIPTION
## Summary
- add `MemoryMonitorPlugin` for visualizing memory usage
- register plugin in `plugins.txt`
- document Memory Monitor in analyzer plugin docs

## Testing
- `npx eslint plugins/analyzer/memory_monitor.js` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_b_685edd8b09f0832a9ace51deba1464dc