### PR TITLE
Add Memory Heatmap plugin

### DIFF
--- a/docs/plugins/analyzer.md
+++ b/docs/plugins/analyzer.md
@@ -9,6 +9,7 @@ A collection of plugins that let you see your music in fascinating ways. These v
 - [Spectrogram](#spectrogram) - Creates beautiful visual patterns from your music
 - [Spectrum Analyzer](#spectrum-analyzer) - Shows the different frequencies in your music
 - [Stereo Meter](#stereo-meter) - Visualizes stereo balance and phase relationships
+- [Memory Heatmap](#memory-heatmap) - Displays JS heap usage to help spot garbage collection
 
 ## Level Meter
 
@@ -164,6 +165,15 @@ A fascinating visualization tool that lets you see how your music creates a sens
   - Lower values: See quick musical changes
   - Higher values: See overall sound patterns
   - Default: 100 ms works well for most music
+
+## Memory Heatmap
+
+This utility plugin visualizes how the JavaScript heap size changes over time. A color bar represents each memory sample, shifting from green (low usage) to red (high usage). When memory suddenly drops, the bar is marked in cyan so you can spot potential garbage collection events.
+
+### Usage Guide
+- Open the plugin to start monitoring automatically.
+- Watch for cyan markers indicating memory was freed by the runtime.
+- Use this information to correlate audio glitches with spikes or drops in memory use.
 
 ### Enjoying Your Music
 1. **Watch Different Styles**

--- a/electron/ipc-handlers.js
+++ b/electron/ipc-handlers.js
@@ -256,6 +256,17 @@ function registerIpcHandlers() {
     return { success: false, error: 'Main window not available' };
   });
 
+  // Provide memory usage info
+  ipcMain.handle('get-memory-info', () => {
+    try {
+      const memInfo = process.memoryUsage();
+      return { success: true, memInfo };
+    } catch (error) {
+      console.error('Error getting memory info:', error);
+      return { success: false, error: error.message };
+    }
+  });
+
   // Handle clear microphone permission request
   ipcMain.handle('clear-microphone-permission', async () => {
     try {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -65,6 +65,9 @@ contextBridge.exposeInMainWorld(
     
     // Get app version
     getAppVersion: () => ipcRenderer.invoke('get-app-version'),
+
+    // Get process memory information
+    getMemoryInfo: () => ipcRenderer.invoke('get-memory-info'),
     
     // Get command line preset file
     getCommandLinePresetFile: () => ipcRenderer.invoke('get-command-line-preset-file'),

--- a/plugins/analyzer/memory_heatmap.css
+++ b/plugins/analyzer/memory_heatmap.css
@@ -1,0 +1,6 @@
+.memory-heatmap-plugin-ui canvas {
+  width: 100%;
+  height: 100px;
+  background: #1a1a1a;
+  display: block;
+}

--- a/plugins/analyzer/memory_heatmap.js
+++ b/plugins/analyzer/memory_heatmap.js
@@ -1,0 +1,90 @@
+class MemoryHeatmapPlugin extends PluginBase {
+  constructor() {
+    super('Memory Heatmap', 'Visualize JS heap usage over time');
+    this.history = [];
+    this.maxPoints = 60; // Number of samples shown
+    this.sampleInterval = 1000; // ms
+    this.canvas = null;
+    this.ctx = null;
+    this.intervalId = null;
+  }
+
+  getParameters() {
+    return { ...super.getParameters() };
+  }
+
+  createUI() {
+    const container = document.createElement('div');
+    container.className = 'plugin-parameter-ui memory-heatmap-plugin-ui';
+
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = 300;
+    this.canvas.height = 100;
+    container.appendChild(this.canvas);
+
+    this.ctx = this.canvas.getContext('2d');
+    this.startMonitoring();
+    return container;
+  }
+
+  startMonitoring() {
+    if (this.intervalId) return;
+    this.fetchAndDraw();
+    this.intervalId = setInterval(() => this.fetchAndDraw(), this.sampleInterval);
+  }
+
+  stopMonitoring() {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  async fetchAndDraw() {
+    try {
+      const result = await window.electronAPI.getMemoryInfo();
+      if (!result || !result.success) return;
+      const memInfo = result.memInfo;
+      const used = memInfo.heapUsed || memInfo.rss || 0;
+      const usedMB = used / (1024 * 1024);
+      this.history.push(usedMB);
+      if (this.history.length > this.maxPoints) this.history.shift();
+      this.draw();
+    } catch (e) {
+      console.error('MemoryHeatmapPlugin fetch error', e);
+    }
+  }
+
+  draw() {
+    if (!this.ctx) return;
+    const ctx = this.ctx;
+    const width = this.canvas.width;
+    const height = this.canvas.height;
+    ctx.clearRect(0, 0, width, height);
+    const max = Math.max(...this.history, 1);
+    const barWidth = width / this.maxPoints;
+    for (let i = 0; i < this.history.length; i++) {
+      const val = this.history[this.history.length - 1 - i];
+      const ratio = val / max;
+      const hue = (1 - ratio) * 120; // green to red
+      ctx.fillStyle = `hsl(${hue},100%,50%)`;
+      const x = width - (i + 1) * barWidth;
+      ctx.fillRect(x, height - ratio * height, barWidth - 1, ratio * height);
+      if (i > 0) {
+        const prev = this.history[this.history.length - i];
+        if (prev - val > 5) { // Drop >5MB indicates GC
+          ctx.fillStyle = 'cyan';
+          ctx.fillRect(x, 0, barWidth - 1, 4);
+        }
+      }
+    }
+  }
+
+  cleanup() {
+    this.stopMonitoring();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.MemoryHeatmapPlugin = MemoryHeatmapPlugin;
+}

--- a/plugins/plugins.txt
+++ b/plugins/plugins.txt
@@ -24,6 +24,7 @@ analyzer/oscilloscope: Oscilloscope | Analyzer | OscilloscopePlugin | css
 analyzer/spectrogram: Spectrogram | Analyzer | SpectrogramPlugin | css
 analyzer/spectrum_analyzer: Spectrum Analyzer | Analyzer | SpectrumAnalyzerPlugin | css
 analyzer/stereo_meter: Stereo Meter | Analyzer | StereoMeterPlugin | css
+analyzer/memory_heatmap: Memory Heatmap | Analyzer | MemoryHeatmapPlugin | css
 basics/channel_divider: Channel Divider | Basics | ChannelDividerPlugin | css
 basics/dc_offset: DC Offset | Basics | DCOffsetPlugin
 basics/matrix: Matrix | Basics | MatrixPlugin | css


### PR DESCRIPTION
## Summary
- create MemoryHeatmapPlugin to visualize JS heap usage
- expose `getMemoryInfo` through preload and ipc handlers
- document the new plugin
- list plugin in plugins.txt

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_685edd8b09f0832a9ace51deba1464dc