### PR TITLE
Fix temp buffer reuse

### DIFF
--- a/plugins/audio-processor.js
+++ b/plugins/audio-processor.js
@@ -438,7 +438,9 @@ class PluginProcessor extends AudioWorkletProcessor {
             // Prepare the context object for the processor call.
             // Avoid spreading unless necessary; pass specific needed properties.
             // Here, we keep the original structure for compatibility.
-            const context = { ...pluginContext, port: port }; // Pass port for potential messaging from plugin
+            // Use the persistent pluginContext directly to allow state reuse (e.g. temp buffers)
+            pluginContext.port = port; // Expose the port for optional messaging
+            const context = pluginContext;
 
 
             // Determine input and output buses for this plugin


### PR DESCRIPTION
## Summary
- reuse plugin contexts instead of cloning them every frame so `_tempBuffer` persists

## Testing
- `npm test` *(fails: Missing script)*
- `node -c plugins/audio-processor.js`

------
https://chatgpt.com/codex/tasks/task_b_685efb9b98d0832aa816468c55e75f4d